### PR TITLE
JS snippet: host has to include the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To show the hCaptcha you need to modify the registration template. You can find 
             window.onload = function(){
                 m = new mosparo(
                    'mosparo-box', 
-                   '${mosparoHost}', 
+                   location.protocol + '//${mosparoHost}',
                    '${mosparoUuid}',
                    '${mosparoPublicKey}', 
                    { loadCssResource: true }


### PR DESCRIPTION
This snippet:
```html
        <script type="module">
            var m;
            window.onload = function(){
                m = new mosparo(
                   'mosparo-box',
                   '${mosparoHost}',
                   '${mosparoUuid}',
                   '${mosparoPublicKey}',
                   { loadCssResource: true }
                );
            };
        </script>
```
needs to include the protocol:
```html
        <script type="module">
            var m;
            window.onload = function(){
                m = new mosparo(
                   'mosparo-box',
                   location.protocol + '//${mosparoHost}',
                   '${mosparoUuid}',
                   '${mosparoPublicKey}',
                   { loadCssResource: true }
                );
            };
        </script>
```
or the variable `mosparoHost` needs to include the proper protocol.

Otherwise, the JS fails to load the data and fails with `CORS request not HTTP`.